### PR TITLE
Change to new generated name

### DIFF
--- a/nanos/setup.rst
+++ b/nanos/setup.rst
@@ -63,12 +63,12 @@ Then you can compile the app:
 
     make BOLOS_ENV=/opt/ledger-blue/ BOLOS_SDK=/home/nanos-secure-sdk
 
-It will generate ``bin/token.hex`` which can be flashed on the Nano S using the Python tools.
+It will generate ``bin/app.hex`` which can be flashed on the Nano S using the Python tools.
 Execute this command on your host environment:
 
 .. code-block:: shell
 
-    docker cp c731409caf59:/home/blue-sample-apps/blue-app-helloworld/bin/token.hex .
+    docker cp c731409caf59:/home/blue-sample-apps/blue-app-helloworld/bin/app.hex .
 
 Replace ``c731409caf59`` by your own container ID (if you do not know it use ``docker ps -a`` to find it).
 
@@ -76,7 +76,7 @@ You can then install the application on your Nano S:
 
 .. code-block:: shell
 
-    python -m ledgerblue.loadApp --targetId 0x31100002 --apdu --fileName token.hex --appName Hello --appFlags 0x00 --icon ""
+    python -m ledgerblue.loadApp --targetId 0x31100002 --apdu --fileName app.hex --appName Hello --appFlags 0x00 --icon ""
 
 You will have to confirm twice on the device to authorize the installation. Once the app is installed, you can select it on the dashboard and launch it by pressing both buttons (to exit this app, also press both buttons).
 

--- a/nanos/setup.rst
+++ b/nanos/setup.rst
@@ -50,13 +50,6 @@ Go back to your docker VM shell:
     git clone https://github.com/LedgerHQ/blue-sample-apps.git
     cd blue-sample-apps/blue-app-helloworld
 
-Edit ``Makefile`` to configure the app to be compiled with the Nano S UI:
-
-.. code-block:: shell
-
-    TARGET_ID = 0x31100002 #Nano S
-    #TARGET_ID = 0x31000002 #Blue
-
 Then you can compile the app:
 
 .. code-block:: shell


### PR DESCRIPTION
After Merging with this [Pull Request](https://github.com/LedgerHQ/blue-sample-apps/pull/4) `Makefile` was edited to take `COMMON_LOAD_PARAMS` from Nano Secure SDK `Makefile`. One of the `COMMON_LOAD_PARAMS` is `--fileName bin/app.hex` Which generates an `app.hex` file instead of `token.hex` as indicated in the documentation. 
Either documentation should be edited or sample `makefiles` are edited to generate `token.hex`