### PR TITLE
Update boilerplate links to new boilerplate app

### DIFF
--- a/source/userspace/getting_started.rst
+++ b/source/userspace/getting_started.rst
@@ -90,14 +90,14 @@ Firstly, download the boilerplate app.
 
 .. code-block:: bash
 
-   git clone https://github.com/LedgerHQ/ledger-app-boilerplate.git
+   git clone https://github.com/LedgerHQ/app-boilerplate.git
 
 Now you can let the Makefile do all the work. The ``load`` target will build the
 app if necessary and load it onto your device over USB.
 
 .. code-block:: bash
 
-   cd ledger-app-boilerplate/
+   cd app-boilerplate/
    make load
 
 And you're done! After confirming the installation on your device, you should


### PR DESCRIPTION
Old links were still pointing to our deprecated boilerplate app :)